### PR TITLE
Optimize floral card page for mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tarjetas para Delia</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="scene">
+      <section class="garden" aria-hidden="true">
+        <div class="stem s1"><span class="flower"></span></div>
+        <div class="stem s2"><span class="flower"></span></div>
+        <div class="stem s3"><span class="flower"></span></div>
+        <div class="stem s4"><span class="flower"></span></div>
+        <span class="leaf l1"></span>
+        <span class="leaf l2"></span>
+        <span class="leaf l3"></span>
+        <span class="leaf l4"></span>
+        <span class="spark p1"></span>
+        <span class="spark p2"></span>
+        <span class="spark p3"></span>
+        <span class="spark p4"></span>
+        <span class="spark p5"></span>
+      </section>
+
+      <section class="card-wrap" aria-live="polite">
+        <article class="card" id="messageCard">
+          <h1>Para Delia 🌸</h1>
+          <p id="messageText"></p>
+        </article>
+        <div class="controls">
+          <button id="prevBtn" type="button" aria-label="Tarjeta anterior">← Anterior</button>
+          <button id="nextBtn" type="button" aria-label="Siguiente tarjeta">Siguiente →</button>
+          <span id="counter" class="counter"></span>
+        </div>
+        <p class="hint">También puedes deslizar la tarjeta en celular ✨</p>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,9 @@
           <span id="counter" class="counter"></span>
         </div>
         <p class="hint">También puedes deslizar la tarjeta en celular ✨</p>
+        <a class="download" href="mensajes-delia.txt" download>
+          ⬇ Descargar mensajes
+        </a>
       </section>
     </main>
 

--- a/mensajes-delia.txt
+++ b/mensajes-delia.txt
@@ -1,0 +1,45 @@
+Delia, yo ni pensé en hacer esta tarjeta… pero algo en mí decidió dejarte este jardín.
+Como si el corazón, sin pedir permiso, supiera que hoy necesitabas un poco de primavera.
+Que estas flores te recuerden que lo que haces importa: escuchar, comprender, sostener.
+
+---
+
+Delia, tu vocación de escuchar y comprender es un acto de amor silencioso.
+Que Dios te sostenga cuando el cansancio sea invisible
+y te dé ánimo cuando la mente se llene de preguntas.
+
+---
+
+Delia, que tu camino no sea una prisa, sino una dirección.
+Que tu fe sea luz en los días claros,
+y brújula en los días nublados.
+
+---
+
+Delia, en un mundo que mide a las personas por resultados,
+que nunca se te olvide lo esencial:
+tu valor no se negocia, se reconoce.
+
+---
+
+Delia, si el día te carga, no lo cargues sola.
+Que tu corazón tenga un lugar donde soltar lo que aprieta,
+y volver a respirar.
+
+---
+
+Delia, que el amor que te rodee sea hogar, no tormenta;
+que te cuide con paciencia,
+y te hable con verdad.
+
+---
+
+Delia, que tu fe no sea ruido: que sea firmeza.
+Que tengas valentía sin dureza,
+y ternura sin miedo.
+
+---
+
+Delia, cuando no sepas qué sigue, entrega el paso de hoy.
+Dios trabaja también en lo pequeño,
+en lo que nadie aplaude.

--- a/script.js
+++ b/script.js
@@ -1,0 +1,61 @@
+const cards = [
+  `Delia, yo ni pensé en hacer esta tarjeta… pero algo en mí decidió dejarte este jardín.\nComo si el corazón, sin pedir permiso, supiera que hoy necesitabas un poco de primavera.\nQue estas flores te recuerden que lo que haces importa: escuchar, comprender, sostener.`,
+  `Delia, tu vocación de escuchar y comprender es un acto de amor silencioso.\nQue Dios te sostenga cuando el cansancio sea invisible\ny te dé ánimo cuando la mente se llene de preguntas.`,
+  `Delia, que tu camino no sea una prisa, sino una dirección.\nQue tu fe sea luz en los días claros,\ny brújula en los días nublados.`,
+  `Delia, en un mundo que mide a las personas por resultados,\nque nunca se te olvide lo esencial:\ntu valor no se negocia, se reconoce.`,
+  `Delia, si el día te carga, no lo cargues sola.\nQue tu corazón tenga un lugar donde soltar lo que aprieta,\ny volver a respirar.`,
+  `Delia, que el amor que te rodee sea hogar, no tormenta;\nque te cuide con paciencia,\ny te hable con verdad.`,
+  `Delia, que tu fe no sea ruido: que sea firmeza.\nQue tengas valentía sin dureza,\ny ternura sin miedo.`,
+  `Delia, cuando no sepas qué sigue, entrega el paso de hoy.\nDios trabaja también en lo pequeño,\nen lo que nadie aplaude.`
+];
+
+const messageCard = document.getElementById('messageCard');
+const messageText = document.getElementById('messageText');
+const counter = document.getElementById('counter');
+const prevBtn = document.getElementById('prevBtn');
+const nextBtn = document.getElementById('nextBtn');
+
+let index = 0;
+let startX = 0;
+
+function renderCard() {
+  messageText.textContent = cards[index];
+  counter.textContent = `Tarjeta ${index + 1} de ${cards.length}`;
+}
+
+function nextCard() {
+  index = (index + 1) % cards.length;
+  renderCard();
+}
+
+function prevCard() {
+  index = (index - 1 + cards.length) % cards.length;
+  renderCard();
+}
+
+prevBtn.addEventListener('click', prevCard);
+nextBtn.addEventListener('click', nextCard);
+
+messageCard.addEventListener('touchstart', (event) => {
+  startX = event.changedTouches[0].clientX;
+});
+
+messageCard.addEventListener('touchend', (event) => {
+  const endX = event.changedTouches[0].clientX;
+  const delta = endX - startX;
+
+  if (Math.abs(delta) < 45) return;
+
+  if (delta < 0) {
+    nextCard();
+  } else {
+    prevCard();
+  }
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowRight') nextCard();
+  if (event.key === 'ArrowLeft') prevCard();
+});
+
+renderCard();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,259 @@
+:root {
+  --bg-1: #1a0010;
+  --bg-2: #250013;
+  --neon-pink: #ff177d;
+  --card-bg: rgba(255, 234, 246, 0.12);
+  --card-border: rgba(255, 149, 206, 0.45);
+  --text: #ffeef8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: "Segoe UI", system-ui, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at 50% 15%, #3a0122 0%, var(--bg-2) 35%, var(--bg-1) 100%);
+}
+
+.scene {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  align-content: start;
+  gap: 1rem;
+  padding: max(1rem, env(safe-area-inset-top)) 0.9rem max(1rem, env(safe-area-inset-bottom));
+}
+
+.garden {
+  width: min(92vw, 360px);
+  height: 180px;
+  margin-inline: auto;
+  position: relative;
+  filter: drop-shadow(0 0 8px rgba(255, 31, 128, 0.4));
+  border-bottom: 3px solid rgba(255, 23, 125, 0.2);
+  transform: scale(0.9);
+  transform-origin: bottom center;
+}
+
+.stem {
+  position: absolute;
+  bottom: 12px;
+  width: 5px;
+  border-radius: 999px;
+  background: linear-gradient(to top, #61012d, #ff177d);
+  transform-origin: bottom;
+  animation: sway 4s ease-in-out infinite;
+}
+
+.s1 { left: 112px; height: 125px; animation-delay: -0.2s; }
+.s2 { left: 166px; height: 160px; animation-delay: -1s; }
+.s3 { left: 224px; height: 145px; animation-delay: -1.9s; }
+.s4 { left: 278px; height: 118px; animation-delay: -2.7s; }
+
+.flower,
+.flower::before,
+.flower::after {
+  content: "";
+  position: absolute;
+  border-radius: 50% 50% 50% 0;
+  background: radial-gradient(circle at 30% 30%, #ff8cc3, var(--neon-pink) 65%);
+}
+
+.flower {
+  width: 24px;
+  height: 24px;
+  top: -16px;
+  left: -10px;
+  transform: rotate(45deg);
+  box-shadow: 0 0 15px rgba(255, 77, 166, 0.85);
+}
+
+.flower::before {
+  width: 24px;
+  height: 24px;
+  transform: rotate(90deg) translate(8px, 0);
+}
+
+.flower::after {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #ffd8e9;
+  top: 8px;
+  left: 8px;
+}
+
+.leaf {
+  position: absolute;
+  bottom: 12px;
+  width: 80px;
+  height: 6px;
+  border-radius: 20px;
+  background: linear-gradient(to right, transparent, #ff177d, transparent);
+  opacity: 0.7;
+}
+
+.l1 { left: 25px; transform: rotate(-58deg); }
+.l2 { left: 88px; transform: rotate(-20deg); width: 110px; }
+.l3 { right: 95px; transform: rotate(24deg); width: 120px; }
+.l4 { right: 30px; transform: rotate(63deg); }
+
+.spark {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #ffcb47;
+  box-shadow: 0 0 8px #ffcb47;
+  animation: float 3.6s ease-in-out infinite;
+}
+
+.p1 { left: 130px; top: 55px; animation-delay: -0.4s; }
+.p2 { left: 176px; top: 40px; animation-delay: -1.1s; }
+.p3 { left: 219px; top: 20px; animation-delay: -1.9s; }
+.p4 { left: 270px; top: 38px; animation-delay: -2.6s; }
+.p5 { left: 312px; top: 75px; animation-delay: -3.2s; }
+
+.card-wrap {
+  width: 100%;
+  max-width: 760px;
+  margin-inline: auto;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 1rem;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.35);
+  animation: breathing 4s ease-in-out infinite;
+}
+
+.card h1 {
+  margin: 0 0 0.7rem;
+  font-size: 1.2rem;
+  color: #ffd7ec;
+}
+
+.card p {
+  margin: 0;
+  line-height: 1.55;
+  font-size: 1rem;
+  white-space: pre-line;
+}
+
+.controls {
+  margin-top: 0.8rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.55rem;
+}
+
+button {
+  border: 1px solid rgba(255, 168, 216, 0.6);
+  background: rgba(255, 91, 171, 0.2);
+  color: #ffe8f4;
+  border-radius: 999px;
+  min-height: 44px;
+  padding: 0.5rem 0.85rem;
+  cursor: pointer;
+  font-size: 0.98rem;
+}
+
+button:active {
+  transform: scale(0.98);
+}
+
+.counter {
+  grid-column: 1 / -1;
+  text-align: center;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.hint {
+  margin-top: 0.35rem;
+  text-align: center;
+  font-size: 0.82rem;
+  opacity: 0.65;
+}
+
+@media (min-width: 700px) {
+  .scene {
+    align-content: center;
+    gap: 1.8rem;
+    padding: 1.5rem;
+  }
+
+  .garden {
+    width: min(420px, 90vw);
+    height: 240px;
+    transform: scale(1);
+  }
+
+  .card {
+    border-radius: 18px;
+    padding: 1.35rem 1.2rem;
+  }
+
+  .card h1 {
+    font-size: clamp(1.25rem, 2vw, 1.7rem);
+  }
+
+  .card p {
+    font-size: clamp(1rem, 1.8vw, 1.1rem);
+  }
+
+  .controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+  }
+
+  .counter {
+    grid-column: auto;
+  }
+}
+
+@keyframes sway {
+  0%,
+  100% {
+    transform: rotate(-4deg) translateY(0);
+  }
+  50% {
+    transform: rotate(4deg) translateY(-3px);
+  }
+}
+
+@keyframes float {
+  0%,
+  100% {
+    opacity: 0.2;
+    transform: translateY(8px) scale(0.7);
+  }
+  45% {
+    opacity: 1;
+    transform: translateY(-8px) scale(1);
+  }
+}
+
+@keyframes breathing {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.01);
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -187,6 +187,24 @@ button:active {
   opacity: 0.65;
 }
 
+
+.download {
+  display: block;
+  margin-top: 0.65rem;
+  text-align: center;
+  text-decoration: none;
+  color: #ffd7ec;
+  border: 1px dashed rgba(255, 168, 216, 0.6);
+  border-radius: 12px;
+  padding: 0.65rem 0.8rem;
+  background: rgba(255, 91, 171, 0.12);
+  min-height: 44px;
+}
+
+.download:active {
+  transform: scale(0.99);
+}
+
 @media (min-width: 700px) {
   .scene {
     align-content: center;


### PR DESCRIPTION
### Motivation
- Make the previously added floral card UI usable and comfortable on mobile devices by improving layout, spacing and touch ergonomics.
- Provide a simple, accessible way to navigate the messages on phones (taps + swipe) while retaining desktop behavior.

### Description
- Add a mobile-first `index.html` with accessible controls and a hint about swipe gestures and keep `aria-live="polite"` for screen readers.
- Replace `styles.css` with a responsive, safe-area aware layout, scaled garden scene for small screens, larger touch targets (`min-height: 44px`) and a 2-column controls layout for mobile that becomes a desktop layout via a media query.
- Update `script.js` to include swipe gesture support on the card (touchstart/touchend with a `45px` threshold) plus keyboard arrow navigation and the existing previous/next button handlers.
- Files touched: `index.html`, `styles.css`, and `script.js`.

### Testing
- Ran `node --check script.js`, which succeeded.
- Started a local static server with `python -m http.server 4173` for visual validation (server started; PID returned).
- Attempted automated screenshot capture via Playwright (WebKit) to validate the mobile view, but the browser connection terminated unexpectedly and the capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69913cf468f8832b912541023c8eabb5)